### PR TITLE
Rename resources to new project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0]
+## [Unreleased]
+
+### Changes
+
+- Change package group from com.bisnode.kafka.authorization to org.openpolicyagent.kafka
+
+## [1.2.0] - 2021-10-12
+
+### Changes
+
+- Ensure compatibility with Kafka 3.0.0 (@scholzj)
+
+## [1.1.0] - 2021-06-11
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  Open Policy Agent plugin for Kafka authorization
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.bisnode.kafka.authorization/opa-authorizer/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.bisnode.kafka.authorization/opa-authorizer)
-![](https://github.com/Bisnode/opa-kafka-plugin/workflows/build/badge.svg)
+![](https://github.com/anderseknert/opa-kafka-plugin/workflows/build/badge.svg)
 [![codecov](https://codecov.io/gh/Bisnode/opa-kafka-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/Bisnode/opa-kafka-plugin)
 
 Open Policy Agent (OPA) plugin for Kafka authorization.
@@ -15,14 +15,14 @@ Open Policy Agent (OPA) plugin for Kafka authorization.
 
 ###
 
-Download the latest OPA authorizer plugin jar from [Releases](https://github.com/Bisnode/opa-kafka-plugin/releases/) (or [Maven Central](https://search.maven.org/artifact/com.bisnode.kafka.authorization/opa-authorizer)) and put the
-file (`opa-authorizer-{$VERSION}.jar`) somewhere Kafka recognizes it - this could be directly  in Kafkas `libs` directory
+Download the latest OPA authorizer plugin jar from [Releases](https://github.com/anderseknert/opa-kafka-plugin/releases/) (or [Maven Central](https://search.maven.org/artifact/com.bisnode.kafka.authorization/opa-authorizer)) and put the
+file (`opa-authorizer-{$VERSION}.jar`) somewhere Kafka recognizes it - this could be directly in Kafka's `libs` directory
 or in a separate plugin directory pointed out to Kafka at startup, e.g:
 
 `CLASSPATH=/usr/local/share/kafka/plugins/*`
 
 To activate the opa-kafka-plugin add the `authorizer.class.name` to server.properties\
-`authorizer.class.name=com.bisnode.kafka.authorization.OpaAuthorizer`
+`authorizer.class.name=org.openpolicyagent.kafka.OpaAuthorizer`
 
 <br />
 The plugin supports the following properties:
@@ -130,7 +130,7 @@ https://kafka.apache.org/24/javadoc/org/apache/kafka/common/resource/ResourceTyp
 
 ### Security protocols:
 
-| Protocol | Decsription |
+| Protocol | Description |
 |---|---|
 | `PLAINTEXT` | Un-authenticated, non-encrypted channel |
 | `SASL_PLAINTEXT` | authenticated, non-encrypted channel |
@@ -167,7 +167,7 @@ The resulting jar (with dependencies embedded) will be named `opa-authorizer-{$V
 
 ## Logging
 
-Set log level `log4j.logger.com.bisnode=INFO` in `config/log4j.properties`
+Set log level `log4j.logger.org.openpolicyagent=INFO` in `config/log4j.properties`
 Use DEBUG or TRACE for debugging.
 
 In a busy Kafka cluster it might be good to tweak the cache since it may produce a lot of log entries in Open Policy Agent, especially if decision logs are turned on. If the policy isn't dynamically updated very often it's recommended to cache a lot to improve performance and reduce the amount of log entries.

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
     id 'signing'
     id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id 'com.bisnode.opa' version '0.3.1'
+    id 'com.bisnode.opa' version '0.3.2'
 }
 
-group 'com.bisnode.kafka.authorization'
+group 'org.openpolicyagent.kafka'
 version '1.2.0'
 
 java {
@@ -21,7 +21,7 @@ repositories {
     mavenCentral()
 }
 
-// See versions used in Kafka here https://github.com/apache/kafka/blob/2.7.0/gradle/dependencies.gradle
+// See versions used in Kafka here https://github.com/apache/kafka/blob/2.8.0/gradle/dependencies.gradle
 dependencies {
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.13', version: '2.10.5'
     implementation group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.8.0'
@@ -38,7 +38,7 @@ shadowJar {
     dependencies {
         exclude(dependency {
             !(it.moduleGroup in [
-                    'com.bisnode.kafka.authorization',
+                    'org.openpolicyagent.kafka',
                     'com.fasterxml.jackson.module',
                     'com.thoughtworks.paranamer',
                     'com.google.guava'
@@ -63,46 +63,40 @@ test {
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId ='com.bisnode.kafka.authorization'
+            groupId ='org.openpolicyagent.kafka'
             artifactId = 'opa-authorizer'
-            version = '1.2.0'
+            version = '1.3.0'
 
             from components.java
 
             pom {
                 name = 'Open Policy Agent plugin for Kafka authorization'
                 description = 'Open Policy Agent (OPA) plugin for Kafka authorization.'
-                url = 'https://github.com/Bisnode/opa-kafka-plugin'
+                url = 'https://github.com/anderseknert/opa-kafka-plugin'
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
                 developers {
                     developer {
                         name = 'Anders Eknert'
-                        email = 'anders.eknert@bisnode.com'
-                        organization = 'Bisnode'
-                        organizationUrl = 'https://www.bisnode.com'
+                        email = 'anders@eknert.com'
+                        organization = 'Styra'
+                        organizationUrl = 'https://www.styra.com'
                     }
                     developer {
-                        name = 'Daniel Olsson'
-                        email = 'daniel.olsson@bisnode.com'
-                        organization = 'Bisnode'
-                        organizationUrl = 'https://www.bisnode.com'
-                    }
-                    developer {
-                        name = 'Łukasz Kamiński'
-                        email = 'lukasz.kaminski@bisnode.com'
-                        organization = 'Bisnode'
-                        organizationUrl = 'https://www.bisnode.com'
+                        name = 'Jakub Scholz'
+                        email = 'jakub@scholz.cz'
+                        organization = 'Red Hat'
+                        organizationUrl = 'https://www.redhat.com'
                     }
                 }
                 scm {
-                    connection = 'scm:git:git://github.com/Bisnode/opa-kafka-plugin.git'
-                    developerConnection = 'scm:git:ssh://github.com/Bisnode/opa-kafka-plugin.git'
-                    url = 'https://github.com/Bisnode/opa-kafka-plugin.git'
+                    connection = 'scm:git:git://github.com/anderseknert/opa-kafka-plugin.git'
+                    developerConnection = 'scm:git:ssh://github.com/anderseknert/opa-kafka-plugin.git'
+                    url = 'https://github.com/anderseknert/opa-kafka-plugin.git'
                 }
             }
         }

--- a/src/main/scala/org/openpolicyagent/kafka/OpaAuthorizer.scala
+++ b/src/main/scala/org/openpolicyagent/kafka/OpaAuthorizer.scala
@@ -1,4 +1,4 @@
-package com.bisnode.kafka.authorization
+package org.openpolicyagent.kafka
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.json.JsonMapper
@@ -37,7 +37,7 @@ class OpaAuthorizer extends Authorizer with LazyLogging {
     .maximumSize(config.getOrElse("opa.authorizer.cache.maximum.size", "50000").toInt)
     .expireAfterWrite(config.getOrElse("opa.authorizer.cache.expire.after.seconds", "3600").toInt, TimeUnit.SECONDS)
     .build
-    .asInstanceOf[Cache[CachableRequest, Boolean]]
+    .asInstanceOf[Cache[CacheableRequest, Boolean]]
 
   override def authorize(requestContext: AuthorizableRequestContext, actions: java.util.List[Action]): java.util.List[AuthorizationResult] = {
     actions.asScala.map { action => authorizeAction(requestContext, action) }.asJava
@@ -56,7 +56,7 @@ class OpaAuthorizer extends Authorizer with LazyLogging {
   }
 
   @VisibleForTesting
-  private[authorization] def getCache = cache
+  private[kafka] def getCache = cache
 
   // None of the below needs implementations
   override def close(): Unit = { }
@@ -87,7 +87,7 @@ class OpaAuthorizer extends Authorizer with LazyLogging {
 
     val host = requestContext.clientAddress.getHostAddress
 
-    val cachableRequest = CachableRequest(principal, action, host)
+    val cachableRequest = CacheableRequest(principal, action, host)
     val request = Request(Input(requestContext, action))
 
     def allowAccess = {
@@ -221,4 +221,4 @@ class AllowCallable(request: Request, opaUrl: URI, allowOnError: Boolean) extend
 
 case class Input(requestContext: AuthorizableRequestContext, action: Action)
 case class Request(input: Input)
-case class CachableRequest(principal: KafkaPrincipal, action: Action, host: String)
+case class CacheableRequest(principal: KafkaPrincipal, action: Action, host: String)

--- a/src/test/scala/org/openpolicyagent/kafka/AzRequestContext.scala
+++ b/src/test/scala/org/openpolicyagent/kafka/AzRequestContext.scala
@@ -1,4 +1,4 @@
-package com.bisnode.kafka.authorization
+package org.openpolicyagent.kafka
 
 import java.net.InetAddress
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}

--- a/src/test/scala/org/openpolicyagent/kafka/OpaAuthorizerBenchmark.scala
+++ b/src/test/scala/org/openpolicyagent/kafka/OpaAuthorizerBenchmark.scala
@@ -1,18 +1,16 @@
-package com.bisnode.kafka.authorization
+package org.openpolicyagent.kafka
 
 import java.net.InetAddress
 import java.util
-import java.util.Collections
 import java.util.concurrent.TimeUnit
 
 import kafka.network.RequestChannel
-import kafka.network.RequestChannel.Session
 import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.resource.PatternType
 import org.apache.kafka.common.resource.ResourceType.TOPIC
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
-import org.apache.kafka.server.authorizer.{AuthorizableRequestContext, Action}
+import org.apache.kafka.server.authorizer.Action
 import scala.jdk.CollectionConverters._
 
 object OpaAuthorizerBenchmark {

--- a/src/test/scala/org/openpolicyagent/kafka/OpaAuthorizerSpec.scala
+++ b/src/test/scala/org/openpolicyagent/kafka/OpaAuthorizerSpec.scala
@@ -1,37 +1,27 @@
-package com.bisnode.kafka.authorization
+package org.openpolicyagent.kafka
 
 import java.net.{InetAddress, URI}
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.HttpResponse.BodyHandlers
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
-import java.util.Collections
-import java.{util => ju}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 import com.typesafe.scalalogging.LazyLogging
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
 import kafka.network.RequestChannel
-import kafka.network.RequestChannel.Session
 import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.resource.PatternType
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.resource.ResourcePattern
-import org.apache.kafka.common.resource.PatternType
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.requests.{RequestContext, RequestHeader}
 import org.apache.kafka.server.authorizer.{Action, AuthorizationResult}
 import org.scalatest._
 import matchers.should._
 import flatspec._
-import org.apache.kafka.common.ClusterResource
-import org.apache.kafka.common.Endpoint
-import scala.compat.java8.FutureConverters
-import io.netty.util.concurrent.Future
-import scala.util.{Success, Failure}
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 
 /**


### PR DESCRIPTION
Prepare for publishing to new Maven target. Use `org.openpolicyagent.kafka` for project.

Signed-off-by: Anders Eknert <anders@eknert.com>