### PR TITLE
Allow reading groups

### DIFF
--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "80:80"
   opa:
-    image: openpolicyagent/opa:0.34.2-rootless
+    image: openpolicyagent/opa:0.35.0-rootless
     ports:
       - "8181:8181"
     command:


### PR DESCRIPTION
Pretty sure the consumer examples used to work, but
when I ran them today they failed with errors like these:

```shell
[2021-12-06 15:57:12,825] ERROR [Consumer clientId=consumer-console-consumer-74904-1, groupId=console-consumer-74904] JoinGroup failed due to fatal error: Group authorization failed. (org.apache.kafka.clients.consumer.internals.AbstractCoordinator)
[2021-12-06 15:57:12,828] ERROR Error processing message, terminating consumer process:  (kafka.tools.ConsoleConsumer$)
org.apache.kafka.common.errors.GroupAuthorizationException: Not authorized to access group: console-consumer-74904
```

Allowing clients to read group data seems innocuous enough,
at least for the purpose of the example.

Also bumped the OPA version to latest.

Signed-off-by: Anders Eknert <anders@eknert.com>