### PR TITLE
Add OPA tutorial companion

### DIFF
--- a/example/opa_tutorial/README.md
+++ b/example/opa_tutorial/README.md
@@ -1,0 +1,15 @@
+# OPA Tutorial Companion Scripts
+
+This directory contains companion scripts for the
+[OPA Kafka tutorial](https://www.openpolicyagent.org/docs/latest/kafka-authorization/) in the OPA docs.
+
+The `create_cert.sh` script will create a server certificate for TLS, along with four client certificates representing
+the four different users used in the tutorial, namely:
+
+* `anon_producer`
+* `anon_consumer`
+* `pii_consumer`
+* `fanout_producer`
+
+These certificates will be stored in the `cert` directory, which is automatically mounted into the Kafka container using
+the Docker compose file.

--- a/example/opa_tutorial/create_cert.sh
+++ b/example/opa_tutorial/create_cert.sh
@@ -26,9 +26,9 @@ echo "123456" > cert/server/credentials.txt
 # Client truststore
 keytool -import -file cert/ca/ca.crt -keystore cert/client/client.truststore -alias ca -storepass 123456 -noprompt
 
-declare -a clients=("alice-mgmt" "alice-producer" "alice-consumer")
+declare -a clients=("pii_consumer" "anon_producer" "anon_consumer" "fanout_producer")
 for client in "${clients[@]}" ; do
-  keytool -genkey -keystore cert/client/"${client}".keystore -alias "${client}" -dname "CN=${client}, OU=developers" -keyalg RSA -validity 3650 -storepass 123456
+  keytool -genkey -keystore cert/client/"${client}".keystore -alias "${client}" -dname "CN=${client}, OU=Developers" -keyalg RSA -validity 3650 -storepass 123456
   keytool -certreq -keystore cert/client/"${client}".keystore -alias "${client}" -file cert/client/"${client}".unsigned.crt -storepass 123456
   openssl x509 -req -sha256 -CA cert/ca/ca.crt -CAkey cert/ca/ca.key -in cert/client/"${client}".unsigned.crt -out cert/client/"${client}".crt -days 3650 -CAcreateserial -passin pass:1234
   keytool -import -file cert/ca/ca.crt -keystore cert/client/"${client}".keystore -alias ca -storepass 123456 -noprompt

--- a/example/opa_tutorial/docker-compose.yaml
+++ b/example/opa_tutorial/docker-compose.yaml
@@ -1,0 +1,57 @@
+services:
+  nginx:
+    image: nginx:1.21.4
+    volumes:
+    - "./bundles:/usr/share/nginx/html"
+    ports:
+    - "80:80"
+  opa:
+    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    ports:
+    - "8181:8181"
+    command:
+    - "run"
+    - "--server"
+    - "--set=decision_logs.console=true"
+    - "--set=services.authz.url=http://nginx"
+    - "--set=bundles.authz.service=authz"
+    - "--set=bundles.authz.resource=bundle.tar.gz"
+    depends_on:
+    - nginx
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.2.1
+    ports:
+    - "2181:2181"
+    environment:
+    - ALLOW_ANONYMOUS_LOGIN=yes
+    - ZOOKEEPER_CLIENT_PORT=2181
+  broker:
+    ports:
+    - "9093:9093"
+    environment:
+      # Set cache expiry to low value for development in order to see decisions
+      KAFKA_OPA_AUTHORIZER_CACHE_EXPIRE_AFTER_SECONDS: 10
+      KAFKA_OPA_AUTHORIZER_URL: http://opa:8181/v1/data/kafka/authz/allow
+      KAFKA_AUTHORIZER_CLASS_NAME: org.openpolicyagent.kafka.OpaAuthorizer
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: SSL://localhost:9093
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SSL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_SSL_KEYSTORE_FILENAME: server.keystore
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: credentials.txt
+      KAFKA_SSL_KEY_CREDENTIALS: credentials.txt
+      KAFKA_SSL_TRUSTSTORE_FILENAME: server.truststore
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: credentials.txt
+      KAFKA_SSL_CLIENT_AUTH: required
+      CLASSPATH: "/plugin/*"
+    volumes:
+    - "./plugin:/plugin"
+    - "./cert/server:/etc/kafka/secrets"
+    depends_on:
+    - opa
+    - zookeeper

--- a/src/main/rego/policy.rego
+++ b/src/main/rego/policy.rego
@@ -105,9 +105,18 @@ on_own_topic(action) {
 	regex.match(owner, action.resourcePattern.name)
 }
 
-username = substring(name, 3, count(name)) {
+username = cn_parts[0] {
 	name := input.requestContext.principal.name
 	startswith(name, "CN=")
-} else = input.requestContext.principal.name {
+	parsed := parse_user(name)
+	cn_parts := split(parsed.CN, ".")
+}
+# If client certificates aren't used for authentication
+else = input.requestContext.principal.name {
 	true
+}
+
+parse_user(user) = {key: value |
+	parts := split(user, ",")
+	[key, value] := split(parts[_], "=")
 }

--- a/src/test/rego/policy_test.rego
+++ b/src/test/rego/policy_test.rego
@@ -34,7 +34,7 @@ test_create_own_topic_as_consumer {
 
 # Producers
 test_produce_own_topic_as_producer {
-	allow with input.requestContext.principal.name as "alice-producer"
+	allow with input.requestContext.principal.name as "CN=alice-producer, OU=Developers"
 		 with input.action as {
 			"operation": "WRITE",
 			"resourcePattern": {
@@ -80,7 +80,7 @@ test_anyone_describe_own_topic {
 
 # MGMT User tests
 test_mgmt_user_own_topic_read {
-	allow with input.requestContext.principal.name as "alice-mgmt"
+	allow with input.requestContext.principal.name as "CN=alice-mgmt, O=AcmeCorp"
 		 with input.action as {
 			"operation": "READ",
 			"resourcePattern": {


### PR DESCRIPTION
Create a new subdirectory in examples for setting up users
for the official OPA docs on Kafka integration. I'd rather
have these kept separately so we can make changes to the
plugin docs without worrying about breaking anything in
the OPA tutorial.

Also made a minor change to policy to allow other attributes
than CN in the client certificate.

Signed-off-by: Anders Eknert <anders@eknert.com>