### PR TITLE
Make Kafka and Jackson compile-only dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,15 @@ repositories {
 
 // See versions used in Kafka here https://github.com/apache/kafka/blob/2.8.0/gradle/dependencies.gradle
 dependencies {
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.13', version: '2.10.5'
-    implementation group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.8.0'
+    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.13', version: '2.10.5'
+    compileOnly group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.8.0'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
-    implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
     testImplementation group: 'org.scalatest', name: 'scalatest_2.13', version: '3.2.5'
     testImplementation group: 'org.scalatestplus', name: 'junit-4-13_2.13', version: '3.2.5.0'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.14.0'
+    testImplementation group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.8.0'
 }
 
 shadowJar {
@@ -39,8 +39,6 @@ shadowJar {
         exclude(dependency {
             !(it.moduleGroup in [
                     'org.openpolicyagent.kafka',
-                    'com.fasterxml.jackson.module',
-                    'com.thoughtworks.paranamer',
                     'com.google.guava'
             ])
         })


### PR DESCRIPTION
The Kafka and Jackson dependencies are currently configured as `implementation` dependencies in the Gradle build. They are both configured as hard dependencies in the published Maven artifacts. And the `jackson-module-scala` together with its `paranamer` dependency is also included in the fat-JAR. As described in #39, this can cause problems when using the authorizer with some other Kafka version than 2.8 and the dependency versions do not match what is used in Kafka. It introduced the different versions of these dependencies into the classpaths and that can lead to various errors.

This PR tries to address it by:
* Marking Kafka and Jackson as `compileOnly` dependencies. That will cause them to be not included in the `pom.xml` file as a hard dependency which needs to be excluded.
* Completely removes the Findbugs dependency which does not seem to be needed
* Removes Jackson and Paranamer from the fat-JAR
* Only actual `implementation` dependency left is Guava which is not part of Apache Kafka an more and needs to be added
* The Kafka dependency is needed for the tests, so it is also added as test dependency

This is not exactly the same as the provided scope for dependencies in Maven, but that does not seem to exist in Gradle. So this should be close to it.
