### PR TITLE
Add truststore configuration for HTTPS connections to OPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [TBD] - 2022-06-23
+
+- Add configuration properties (opa.authorizer.truststore.*) for truststore for HTTPS connections to OPA ([@iamatwork](https://github.com/@iamatwork))
+
 ## [1.4.0] - 2022-01-11
 
 - Collect and expose JMX metrics from OPA authorizer ([@quangminhtran94](https://github.com/quangminhtran94))

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The plugin supports the following properties:
 | `opa.authorizer.cache.expire.after.seconds` | `3600` | `3600` | Decision cache expiry in seconds. |
 | `opa.authorizer.metrics.enabled` | `true` | `false` | Whether or not expose JMX metrics for monitoring. |
 | `super.users` | `User:alice;User:bob` |  | Super users which are always allowed. |
+| `opa.authorizer.truststore.path` | `/path/to/mytruststore.p12` |  | Path to the PKCS12 truststore for HTTPS requests to OPA. |
+| `opa.authorizer.truststore.password` | `ichangedit` | `changeit` | Password for the truststore. |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The plugin supports the following properties:
 | `super.users` | `User:alice;User:bob` |  | Super users which are always allowed. |
 | `opa.authorizer.truststore.path` | `/path/to/mytruststore.p12` |  | Path to the PKCS12 truststore for HTTPS requests to OPA. |
 | `opa.authorizer.truststore.password` | `ichangedit` | `changeit` | Password for the truststore. |
+| `opa.authorizer.truststore.type` | `PKCS12`, `JKS` or whatever your JVM supports | `PKCS12` | Type of the truststore. |
 
 ## Usage
 


### PR DESCRIPTION
Hello,

please consider my pull-request.

I've added two properties to configure a truststore for HTTPS to OPA.

When a truststore is configured, the connection factory is replaced with a new one, that has an additional SslContext. Otherwise nothing has changed.

To expose metrics over the network we want to enable HTTPS in OPA. This forces HTTPS for all connections. This shouldn't impact performance, because the connections should be kept open by Java's default behavior.

I've tested the change in our dev-environment, and everything worked fine.

Thanks,
Lukas
